### PR TITLE
[Chore] better .gitignore for locales files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,8 +9,8 @@ build/
 
 
 # Locales
-locales/*
-!locales/en.json
+**/locales/*
+!**/locales/en.json
 
 
 # OS generated files


### PR DESCRIPTION
Better ignoring path to make sure any locales folder, whether it's in client/app/ or not (like contexts), is to be ignored except the en.json file inside.