### PR TITLE
[feat] Add default route tout manifest.webapp

### DIFF
--- a/manifest.webapp
+++ b/manifest.webapp
@@ -17,5 +17,12 @@
       "description": "Required to display a localized Ui",
       "access": "read"
     }
+  },
+  "routes": {
+    "/": {
+      "folder": "/",
+      "index": "index.html",
+      "public": true
+    }
   }
 }


### PR DESCRIPTION
Allows to make a default app works with `cozy-stack serve-appdir`.