### PR TITLE
chore: avoid nested imports

### DIFF
--- a/config/webpack.config.base.js
+++ b/config/webpack.config.base.js
@@ -13,6 +13,7 @@ module.exports = {
     filename: 'app.js'
   },
   resolve: {
+    modules: ['node_modules', 'src'],
     extensions: ['', '.js', '.json', '.css']
   },
   module: {

--- a/config/webpack.target.mobile.js
+++ b/config/webpack.target.mobile.js
@@ -6,6 +6,9 @@ const webpack = require('webpack')
 const {production} = require('./webpack.vars')
 
 module.exports = {
+  resolve: {
+    modules: ['node_modules', 'src', 'mobile/src']
+  },
   entry: [path.resolve(__dirname, '../mobile/src/main')],
   output: {
     path: path.resolve(__dirname, '../mobile/www')


### PR DESCRIPTION
following the advice from the following website
https://www.sitepoint.com/organize-large-react-application/\#configurewebpacksmodulesresolutiontoavoidnestedimports

Then, instead of

```js
import foo from './foo'
import bar from '../../../bar'
import baz from '../../lib/baz'
```

we could write this

```js
import foo from './foo'
import bar from 'app/bar' // => src/app/bar
import baz from 'an/example/import' // => src/an/example/import
```