### PR TITLE
chore: add short hash to css classes

### DIFF
--- a/config/webpack.config.cozy-ui.js
+++ b/config/webpack.config.cozy-ui.js
@@ -11,7 +11,7 @@ module.exports = {
       {
         test: /\.styl$/,
         loader: extractor.extract('style', [
-          'css-loader?importLoaders=1&modules',
+          'css-loader?importLoaders=1&modules&localIdentName=[local]--[hash:base64:5]',
           'postcss-loader',
           'stylus-loader'
         ])


### PR DESCRIPTION
Too much hash is not good for your health.

https://github.com/cozy/cozy-data-connect/pull/53#discussion_r116802400

With this change, unscrutable css classes like `_3tMtInO5C4jPcI_4i_Cq2l` become `coz-nav-item--3tMtI` ✨ 