### PR TITLE
chore: add missing proptypes

### DIFF
--- a/src/components/App.jsx
+++ b/src/components/App.jsx
@@ -8,4 +8,8 @@ const App = ({ t }) => (
   <h1 className={classNames(styles['title'])}>{ t('App.welcome') }</h1>
 )
 
+App.propTypes = {
+  t: React.PropTypes.func
+}
+
 export default translate()(App)

--- a/src/lib/I18n.js
+++ b/src/lib/I18n.js
@@ -77,6 +77,13 @@ export class I18n extends Component {
   }
 }
 
+I18n.propTypes = {
+  lang: React.PropTypes.string,
+  context: React.PropTypes.object,
+  children: React.PropTypes.element,
+  locale: React.PropTypes.string
+}
+
 I18n.childContextTypes = {
   t: React.PropTypes.func,
   f: React.PropTypes.func


### PR DESCRIPTION
After the introduction of `eslint-standard`, linter was screaming for some proptypes.